### PR TITLE
Add a unique id to the saver.saver entity

### DIFF
--- a/custom_components/saver/__init__.py
+++ b/custom_components/saver/__init__.py
@@ -171,6 +171,7 @@ class SaverEntity(RestoreEntity):
     def __init__(self) -> None:
         self._entities_db = {}
         self._variables_db = {}
+        self._attr_unique_id = "saver.saver"
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Fixes #26

This adds a unique id to the `saver.saver` entity. Due to only being able to have a single saver configured at a time, I just set the id to `saver.saver`. This allows configuration via the web interface.