### PR TITLE
Fix scene.apply failures in convert_to_scene_params (None values + incomplete temperature range)

### DIFF
--- a/custom_components/saver/__init__.py
+++ b/custom_components/saver/__init__.py
@@ -427,11 +427,15 @@ class SaverEntity(RestoreEntity):
     def convert_to_scene_params(saved_state: Any) -> dict[str, Any]:
         state = saved_state["state"] if isinstance(saved_state, dict) else saved_state.state
         attrs = saved_state["attributes"] if isinstance(saved_state, dict) else saved_state.attributes
-        return {
-            "state": state,
-            **{
-                attr_key: json.loads(json.dumps(attr_val))
-                for attr_key, attr_val in attrs.items()
-                if attr_key not in IGNORED_ATTRIBUTES and attr_val is not None
-            },
+        attr_dict = {
+            attr_key: json.loads(json.dumps(attr_val))
+            for attr_key, attr_val in attrs.items()
+            if attr_key not in IGNORED_ATTRIBUTES and attr_val is not None
         }
+        # HA climate reproduce_state requires target_temp_low and target_temp_high together
+        # (voluptuous inclusion group). Drop both if only one is present — e.g. Better Thermostat
+        # uses heat_cool mode but only stores target_temp_low, never target_temp_high.
+        if ("target_temp_low" in attr_dict) != ("target_temp_high" in attr_dict):
+            attr_dict.pop("target_temp_low", None)
+            attr_dict.pop("target_temp_high", None)
+        return {"state": state, **attr_dict}

--- a/custom_components/saver/__init__.py
+++ b/custom_components/saver/__init__.py
@@ -432,6 +432,6 @@ class SaverEntity(RestoreEntity):
             **{
                 attr_key: json.loads(json.dumps(attr_val))
                 for attr_key, attr_val in attrs.items()
-                if attr_key not in IGNORED_ATTRIBUTES
+                if attr_key not in IGNORED_ATTRIBUTES and attr_val is not None
             },
         }


### PR DESCRIPTION
Two related issues in convert_to_scene_params cause scene.apply — and therefore restore_state — to fail silently for all entities in the batch.

---
Fix 1 (https://github.com/PiotrMachowski/Home-Assistant-custom-components-Saver/pull/63/commits/3661033c73828caf823eb1721aa364a2f035f490): skip attributes whose stored value is None

Entities can have attributes set to None at save time (e.g. a climate entity in off mode with target_temp_high=None). When restore_state is called, scene.apply rejects None for any typed field and raises an error.

Omitting None attributes is always correct — scene.apply has no way to apply them regardless of entity domain. Falsy-but-valid values (0, False, "", []) are unaffected.

Error (before fix):
```ERROR [homeassistant.core] Error executing service:
  <ServiceCall scene.apply: entities=climate.my_thermostat=
  <state climate.my_thermostat=off; target_temp_high=None, ...>>
```

---
Fix 2 (https://github.com/PiotrMachowski/Home-Assistant-custom-components-Saver/pull/63/commits/058f163305e7899e207ad688bc2579b225170325): drop incomplete target_temp_low / target_temp_high pairs

HA's climate/reproduce_state.py validates temperature data through a voluptuous inclusion group: if target_temp_low or target_temp_high is present, both must be provided — otherwise the schema raises MultipleInvalid. Some integrations (e.g. Better Thermostat (https://github.com/KartoffelToby/better_thermostat)) operate in heat_cool mode but only write target_temp_low to their state, never target_temp_high. Saving and restoring such an entity triggers this error, again failing the entire batch silently.

When both values are present, behaviour is unchanged.

Error (before fix):
```
ERROR [homeassistant.core] Error executing service: <ServiceCall scene.apply ...>
...
voluptuous.error.MultipleInvalid: some but not all values in the same group
of inclusion 'temperature' @ data[<temperature>]
```